### PR TITLE
Ajuste no processPermissions para lista vazia

### DIFF
--- a/packages/studio/app/composables/ApiClient.ts
+++ b/packages/studio/app/composables/ApiClient.ts
@@ -211,12 +211,12 @@ class ApiClient {
     })
   }
 
-  public async deletePermission(role_id: string, table_id: string): Promise<void> {
-    await this.request(`collections/${table_id}/permissions`, {
+  public async deletePermission(role_id: string, collection: string): Promise<void> {
+    await this.request(`collections/${collection}/permissions`, {
       method: 'DELETE',
       body: JSON.stringify({
         role_id,
-        table_id,
+        collection,
       }),
     })
   }

--- a/packages/studio/app/pages/admin/collections/permissions/[collection].vue
+++ b/packages/studio/app/pages/admin/collections/permissions/[collection].vue
@@ -63,14 +63,24 @@ function items(row: any) {
 }
 
 function processPermissions() {
-  processedPermissions.value = collections.value.map((permission: any) => ({
-    tableName: permission.collection,
-    roleName: permission.role.name,
-    can_create: permission.can_create,
-    can_read: permission.can_read,
-    can_update: permission.can_update,
-    can_delete: permission.can_delete,
-  }))
+  try {
+    if (Array.isArray(collections.value)) {
+      processedPermissions.value = collections.value.map((permission: any) => ({
+        tableName: permission.collection,
+        roleName: permission.role.name,
+        can_create: permission.can_create,
+        can_read: permission.can_read,
+        can_update: permission.can_update,
+        can_delete: permission.can_delete,
+      }))
+    } else {
+      console.warn('collections.value is not an array');
+      processedPermissions.value = [];
+    }
+  }
+  catch (error) {
+    console.error('Error processing permissions:', error)
+  }
 }
 
 function findRoleId(tableName: string, roleName: string): string | null {


### PR DESCRIPTION
A origem do erro vinha de apos apagar a permission, ele rodava o process permissions, que estava levantando erro se n~ao houvesse permissao nenhuma para listar. 